### PR TITLE
Earn clean build  & test badge

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,10 +35,9 @@ jobs:
       - name: go build
         run: go build ./...
       - name: go test
-        if: always()
         run: |
           echo "## Go test" >> $GITHUB_STEP_SUMMARY
-          go test ./... |tee gotest.log >> $GITHUB_STEP_SUMMARY
+          go test -v -cover ./... |tee gotest.log >> $GITHUB_STEP_SUMMARY
       - name: Post status to Slack testing_builds
         if: always()
         uses: act10ns/slack@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,6 +38,12 @@ jobs:
         run: |
           echo "## Go test" >> $GITHUB_STEP_SUMMARY
           go test -v -cover ./... |tee gotest.log >> $GITHUB_STEP_SUMMARY
+          if grep -q "FAIL" gotest.log; then
+            echo "## Go test failed" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          else
+            echo "## Go test passed" >> $GITHUB_STEP_SUMMARY
+          fi
       - name: Post status to Slack testing_builds
         if: always()
         uses: act10ns/slack@v2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/:license-apache-blue.svg)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/go.izuma.io/conftagz)](https://goreportcard.com/report/go.izuma.io/IzumaNetworks/conftagz)
+[![Build and Test](https://github.com/IzumaNetworks/conftagz/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/IzumaNetworks/conftagz/actions/workflows/build-and-test.yml)
 
 ```
 go get go.izuma.io/conftagz

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ func main() {
 	// Run conftagz on the config struct
 	// to validate the config, sub any env vars,
 	// and put in defaults for missing items
-	err2 := conftagz.Process(nil, &config)
-	if err2 != nil {
+	err = conftagz.Process(nil, &config)
+	if err != nil {
 		// some test tag failed
-		log.Fatalf("Config is bad: %v\n", err2)
+		log.Fatalf("Config is bad: %v\n", err)
 	} else {
 		fmt.Printf("Config good.\n")
 	}
@@ -105,7 +105,7 @@ Config: {https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXX
 
 There are many powerful and complicated libraries for configuration options and flags. [cobra](https://github.com/spf13/cobra), [viper](https://github.com/spf13/viper), [kong](https://github.com/alecthomas/kong), etc. But frankly software is already complex enough - and the last thing I wanted is some complicated library to just process command line arguments and config files. `conftagz` is the antithesis of these approaches.
 
-When I go back to look at something from months ago - I want it to be super easy to figure out what's going on with the conf files and flags... Nor do I want to be confined to a specific way to layout components, or have to call dozens of library functions just to get the CLI options.
+When I go back to look at something from months ago - I want it to be super easy to figure out what is going on with the conf files and flags. Nor do I want to be confined to a specific way to layout components, or have to call dozens of library functions just to get the CLI options.
 
 ### Just use struct tags
 
@@ -124,11 +124,11 @@ You can do all this with just struct tags using this package. Then make one call
 
 `conftagz` attempts to eleminate code writing for as much of this as possible by offering:
 
-A `flag:` and (optional) `usage:` tag. This allows setting specific struct fields to be set by a command line flag. Uses the standrd `flag` package.
+A `flag:` and (optional) `usage:` tag. This allows setting specific struct fields to be set by a command line flag. Uses the standard `flag` package.
 
 A `cflag:` `usage:` and `cobra:` flag allow you to use [cobra](https://github.com/spf13/cobra) instead of the normal stdlib `flags` package. See [Using Cobra for flags](#using-cobra-for-flags) section.
 
-A `env:` struct tag which will replace the value of the field with the contents of the env var if present.
+An `env:` struct tag which will replace the value of the field with the contents of the env var if present.
 
 A `test:` struct tag which provides some basic validation (comparison, regex) or allows the calling of a custom func to check a value.
 
@@ -142,7 +142,7 @@ All tags are optional. Fields with no tag above are just ignored.
 
 `conftagz` behavior is specifically designed to complement the behavior of the `yaml.v2` parser that almost everyone uses.
 
-Obviously, `conftagz` makes uses of the `reflect` package to do all this.
+`conftagz` makes uses of the `reflect` package to do all this.
 
 ### Type support:
 
@@ -151,12 +151,12 @@ Fundamental types:
 - `bool` (not supported by `default:` tag as unnecessary)
 - `float32` and `float64`
 - `string` ... `conftagz` uses the golang regex std library for regex tests
-- pointers to all the above - `conftagz` will create the item if the pointer is nil _and_ a default or env var are applied.
+- pointers to all the above - `conftagz` will create the item if the pointer is `nil` _and_ a default or env var are applied.
 
 Structs & Slices
 - Supports both and also their pointers
 - Support for slices of structs and slices of pointers to structs 
-- Default structs can be created if the yaml parser left a struct pointer nil by using a custom `DefaultFunc` like `default:"$(mydefaultfunc)"` See _custom defaults_
+- Default structs can be created if the yaml parser left a struct pointer `nil` by using a custom `DefaultFunc` like `default:"$(mydefaultfunc)"` See _custom defaults_
 - `conftagz` will automatically create a new struct if the struct pointer is `nil`. This behavior can be avoided with `conf:"skip"` or `conf:"skipnil"`
 - Nil slices of pointers to structs will be left alone without a custom function
 
@@ -341,10 +341,10 @@ Custom functions allow various arbitrary tests. Because the function signature i
 The easiest way to use conftagz is:
 
 ```go
-	err2 := conftagz.Process(nil, &config)
-	if err2 != nil {
+	err := conftagz.Process(nil, &config)
+	if err != nil {
 		// some test tag failed
-        log.Fatalf("Config is bad: %v\n", err2)
+        log.Fatalf("Config is bad: %v\n", err)
 	} else {
 		fmt.Printf("Config good.\n")
 	}
@@ -413,16 +413,16 @@ rootCmd.ParseFlags(os.Args)
 otherCmd.ParseFlags(os.Args)
 
 // Run conftagz on the structs
-err2 := conftagz.Process(nil, &config)
-err2 = conftagz.Process(nil, &anotherstuct)
+err = conftagz.Process(nil, &config)
+err = conftagz.Process(nil, &anotherstuct)
 
 // your structs should be filled in if flags were used
 ```
 
-See `examples/examplecobra` for a fully working example.
+See [`examples/examplecobra`](examples/examplecobra/app.go) for a fully working example.
 
 ## Examples
 
-More docs to follow. See the `examples` folder for more examples.
+More docs to follow. See the [`examples`](examples) folder for more examples.
 
 Also refer to the test files for more.

--- a/cobratags.go
+++ b/cobratags.go
@@ -584,7 +584,7 @@ func ProcessCobraTags(somestruct interface{}, opts *CobraFieldSubstOpts) (ret *P
 				if len(tag) > 0 {
 					existing, ok := ret.needflags[tag] // check if we already have a retriever for this flag
 					if ok {
-						setFlagVal(parentpath, field.Name, fieldValue, tag, stag, usagetag, existing, pflags)
+						_, err = setFlagVal(parentpath, field.Name, fieldValue, tag, stag, usagetag, existing, pflags)
 						if err != nil {
 							return
 						}

--- a/cobratags.go
+++ b/cobratags.go
@@ -34,7 +34,6 @@ type cobraFlagSetRetriever struct {
 	retrievers []cobraFlagRetrieverFunc
 	//val        interface{}
 
-	touched bool
 	// unfortunately spf13/pflag does not implement the flag.Func() functions since it's like almost
 	// never updated, so we resort to just using its function which return pointers to vars if the flag is seen
 	varstr  string

--- a/conftags_test.go
+++ b/conftags_test.go
@@ -130,17 +130,21 @@ func TestProcessCobraTags(t *testing.T) {
 	}
 	err := PreProcessCobraFlags(mystruct, nil)
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Errorf("Unexpected error with PreProcessCobraFlags: %v", err)
 		return
 	}
-	rootCmd.ParseFlags(argz)
+	err = rootCmd.ParseFlags(argz)
+	if err != nil {
+		t.Errorf("Unexpected error with rootCmd.ParseFlags: %v", err)
+		return
+	}
 	//	PostProcessCobraFlags()
 
 	err = Process(&ConfTagOpts{
 		//	FlagTagOpts: flagtagopts,
 	}, mystruct)
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Errorf("Unexpected error w Process: %v", err)
 		return
 	}
 

--- a/conftagsdefs.go
+++ b/conftagsdefs.go
@@ -56,7 +56,7 @@ func skipIfZero(confops map[string]string) bool {
 }
 
 // true if the env var must exist, returns an error if it does not
-func mustEnv(confops map[string]string) bool {
+func mustEnv(confops map[string]string) bool { // nolint:golint,unused
 	if _, ok := confops["mustenv"]; ok {
 		return true
 	}
@@ -89,7 +89,7 @@ func testSkip(confops map[string]string) bool {
 
 // true if the envvar should always replace a value
 // if the env var exists
-func preferEnv(confops map[string]string) bool {
+func preferEnv(confops map[string]string) bool { // nolint:golint,unused
 	if _, ok := confops["preferenv"]; ok {
 		return true
 	}
@@ -97,7 +97,7 @@ func preferEnv(confops map[string]string) bool {
 }
 
 // if true then env var is only used if the field has the zero value
-func backupEnv(confops map[string]string) bool {
+func backupEnv(confops map[string]string) bool { // nolint:golint,unused
 	if _, ok := confops["backupenv"]; ok {
 		return true
 	}
@@ -106,7 +106,7 @@ func backupEnv(confops map[string]string) bool {
 
 // if true, then this test will only warn and never
 // cause an error to return
-func testWarn(confops map[string]string) bool {
+func testWarn(confops map[string]string) bool { // nolint:golint,unused
 	if _, ok := confops["testwarn"]; ok {
 		return true
 	}

--- a/examples/example/app.go
+++ b/examples/example/app.go
@@ -25,18 +25,19 @@ func ValidTimeDuration(val interface{}, fieldname string) bool {
 func RunMain() {
 
 	var config Config
+	var confFileName string = "config.yaml"
 
 	// load config file from yaml using yaml parser
 	// Read the yaml file
-	data, err := os.ReadFile("config.yaml")
+	data, err := os.ReadFile(confFileName)
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		log.Fatalf("error with ReadFile(%s): %v", confFileName, err)
 	}
 
 	// Unmarshal the yaml file into the config struct
 	err = yaml.Unmarshal([]byte(data), &config)
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		log.Fatalf("error with yaml.Unmarshal: %v", err)
 	}
 	// register that custom test
 	conftagz.RegisterTestFunc("validtimeduration", ValidTimeDuration)
@@ -44,16 +45,14 @@ func RunMain() {
 	// Run conftagz on the config struct
 	// to validate the config, sub any env vars,
 	// and put in defaults for missing items
-	err2 := conftagz.Process(nil, &config)
-	if err2 != nil {
+	err = conftagz.Process(nil, &config)
+	if err != nil {
 		// some test tag failed
-		log.Fatalf("Config is bad: %v\n", err2)
+		log.Fatalf("Config is bad: %v\n", err)
 	} else {
 		fmt.Printf("Config good.\n")
 	}
-
 	fmt.Printf("Config: %v\n", config)
-
 }
 
 func main() {

--- a/examples/example/app_test.go
+++ b/examples/example/app_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
 func TestExampleAppExecution(t *testing.T) {
+	originalArgs := os.Args
+	// Ensure os.Args is restored after this test
+	defer func() { os.Args = originalArgs }()
+
+	// No arguments
+	os.Args = []string{""}
 	RunMain()
 	t.Log("Example ran successfully")
 }

--- a/examples/example/app_test.go
+++ b/examples/example/app_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestAppExecution(t *testing.T) {
+func TestExampleAppExecution(t *testing.T) {
 	RunMain()
 	t.Log("Example ran successfully")
 }

--- a/examples/example/config.yaml
+++ b/examples/example/config.yaml
@@ -1,2 +1,2 @@
-webhook_url: https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
+webhook_url: https://hooks.example.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
 port: 8080

--- a/examples/example2/app_test.go
+++ b/examples/example2/app_test.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
 // Build and run the application to test it.
 // Any issues in the example should return non-zero exit code.
 func TestExample2Execution(t *testing.T) {
+	originalArgs := os.Args
+	// Ensure os.Args is restored after this test
+	defer func() { os.Args = originalArgs }()
+	// No arguments - original arguments can contain some test configs,
+	// which messes the test
+	os.Args = []string{""}
+
 	RunMain()
 	t.Log("Example2 ran successfully")
 }

--- a/examples/example2/app_test.go
+++ b/examples/example2/app_test.go
@@ -6,7 +6,7 @@ import (
 
 // Build and run the application to test it.
 // Any issues in the example should return non-zero exit code.
-func TestAppExecution(t *testing.T) {
+func TestExample2Execution(t *testing.T) {
 	RunMain()
-	t.Log("Example ran successfully")
+	t.Log("Example2 ran successfully")
 }

--- a/examples/example2/config.yaml
+++ b/examples/example2/config.yaml
@@ -1,8 +1,8 @@
-webhook_url: https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
+webhook_url: https://hooks.example.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
 port: 8080
 sslstuff:
-  cert: adasdaskdalksdhajksdhajksdhaksjd
-  key: asdklasjdkajsdklasjdlkasjdklajsd
+  cert: DummyPublicCertificateDataJustanexample_not_leaking_any_secrets
+  key: DummyPrivateCertificateDataJustanexample_not_leaking_any_secrets
 servers:
   - name: server1
     ip: 192.168.1.1

--- a/examples/examplecobra/app.go
+++ b/examples/examplecobra/app.go
@@ -102,15 +102,16 @@ func RunMain() {
 
 	// load config file from yaml using yaml parser
 	// Read the yaml file
-	data, err := os.ReadFile("config.yaml")
+	var confFileName string = "config.yaml"
+	data, err := os.ReadFile(confFileName)
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		log.Fatalf("error with os.Readfile(%s): %v", confFileName, err)
 	}
 
 	// Unmarshal the yaml file into the config struct
 	err = yaml.Unmarshal([]byte(data), &config)
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		log.Fatalf("error with Unmarshal: %v", err)
 	}
 
 	defaultLogSetupFunc := func(fieldname string) interface{} {
@@ -143,32 +144,41 @@ func RunMain() {
 	// Force cobra to parse the flags before running conftagz.Process
 	// You will need to parse all the flags for all the commands
 	// which have any conftagz fields
-	rootCmd.ParseFlags(os.Args)
-	otherCmd.ParseFlags(os.Args)
+	err = rootCmd.ParseFlags(os.Args)
+	if err != nil {
+		log.Fatalf("Unexpected error on rootCmd.ParseFlags: %v", err)
+	}
+	err = otherCmd.ParseFlags(os.Args)
+	if err != nil {
+		log.Fatalf("Unexpected error on otherCmd.ParseFlags: %v", err)
+	}
 
 	// Run conftagz on the config struct
 	// to validate the config, sub any env vars, and put in defaults for missing items
 	// pass in the optionn to use our own flag set
 	// In the case of cobra tags - in options in os.Args will now be filled into the struct
-	err2 := conftagz.Process(nil, &config)
+	err = conftagz.Process(nil, &config)
 
-	if err2 != nil {
-		log.Fatalf("Config is bad: %v\n", err2)
+	if err != nil {
+		log.Fatalf("Config is bad: %v\n", err)
 	} else {
 		fmt.Printf("Config good.\n")
 	}
 
 	// You can call conftagz on multiple structs
-	err2 = conftagz.Process(nil, &anotherstuct)
-	if err2 != nil {
-		log.Fatalf("AnotherStruct is bad: %v\n", err2)
+	err = conftagz.Process(nil, &anotherstuct)
+	if err != nil {
+		log.Fatalf("AnotherStruct is bad: %v\n", err)
 	} else {
 		fmt.Printf("AnotherStruct good.\n")
 	}
 
 	fmt.Printf("AnotherField: %s\n", anotherstuct.AnotherField)
 
-	rootCmd.Execute()
+	err = rootCmd.Execute()
+	if err != nil {
+		log.Fatalf("Unexpected error on rootCmd.Execute: %v", err)
+	}
 }
 
 // RunMain is the main entry point for the application

--- a/examples/examplecobra/app_test.go
+++ b/examples/examplecobra/app_test.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
 // Build and run the application to test it.
 // Any issues in the example should return non-zero exit code.
 func TestExampleCobraExecution(t *testing.T) {
+	originalArgs := os.Args
+	// Ensure os.Args is restored after this test
+	defer func() { os.Args = originalArgs }()
+	// No arguments - original arguments can contain some test configs,
+	// which messes the test
+	os.Args = []string{""}
 	RunMain()
 	t.Log("Examplecobra ran successfully")
 }

--- a/examples/examplecobra/app_test.go
+++ b/examples/examplecobra/app_test.go
@@ -6,7 +6,7 @@ import (
 
 // Build and run the application to test it.
 // Any issues in the example should return non-zero exit code.
-func TestAppExecution(t *testing.T) {
+func TestExampleCobraExecution(t *testing.T) {
 	RunMain()
-	t.Log("Example ran successfully")
+	t.Log("Examplecobra ran successfully")
 }

--- a/examples/examplecobra/config.yaml
+++ b/examples/examplecobra/config.yaml
@@ -1,8 +1,8 @@
-webhook_url: https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
+webhook_url: https://hooks.example.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
 port: 8080
 sslstuff:
-  cert: adasdaskdalksdhajksdhajksdhaksjd
-  key: asdklasjdkajsdklasjdlkasjdklajsd
+  cert: DummyPublicCertificateDataJustanexample_not_leaking_any_secrets
+  key: DummyPrivateCertificateDataJustanexample_not_leaking_any_secrets
 servers:
   - name: server1
     ip: 192.168.1.1

--- a/flaglookup.go
+++ b/flaglookup.go
@@ -89,7 +89,7 @@ type ProcessedFlagTags struct {
 
 func (p *ProcessedFlagTags) GetFlagsFound() (ret []string) {
 	ret = make([]string, 0)
-	for k, _ := range p.needflags {
+	for k := range p.needflags {
 		ret = append(ret, k)
 	}
 	return
@@ -540,7 +540,7 @@ func ProcessFlagTags(somestruct interface{}, opts *FlagFieldSubstOpts) (ret *Pro
 				if len(tag) > 0 {
 					existing, ok := ret.needflags[tag] // check if we already have a retriever for this flag
 					if ok {
-						setFlagVal(parentpath, field.Name, fieldValue, tag, usagetag, existing)
+						_, err = setFlagVal(parentpath, field.Name, fieldValue, tag, usagetag, existing)
 						if err != nil {
 							return
 						}

--- a/testtag.go
+++ b/testtag.go
@@ -465,7 +465,7 @@ func parseTestVal(tagval string) (ret *testConfOp, err error) {
 	return
 }
 
-// RUns through all test:"" tags to see if the current value passes the test
+// Runs through all test:"" tags to see if the current value passes the test
 func RunTestFlags(somestruct interface{}, opts *TestFieldSubstOpts) (ret []string, err error) {
 
 	var innerTest func(parentpath string, somestruct interface{}) (err error)

--- a/testtag.go
+++ b/testtag.go
@@ -457,9 +457,10 @@ func parseTestVal(tagval string) (ret *testConfOp, err error) {
 			if ret == nil {
 				ret = &testConfOp{}
 			}
-			if op != nil {
-				ret.ops = append(ret.ops, op)
-			}
+			// op is guaranteed to be non-nil at this stage
+			// testtag.go:460:7: SA4031: this nil check is always true (staticcheck)
+			// if op != nil {
+			ret.ops = append(ret.ops, op)
 		}
 	}
 	return


### PR DESCRIPTION
* Add build & test badge to `README.md`.
* Fix all [`golangci-lint`](https://golangci-lint.run/) issues.
* Fix the test failure with example2.
* Clean up the examples a bit (example certificate content, remove usage of err2 etc.).
* Make the test fail for real in the CI.
    * It should have failed already earlier, locally go test returns 1 if a test fails.
    * In CI that did not seem to happen, which I cannot explain.
    * Now we look explicitly for the FAIL string.

```
$ goreportcard-cli
Grade ........... A+ 96.8%
Files ................. 22
Issues ................. 6
gofmt ............... 100%
go_vet .............. 100%
gocyclo .............. 72%
ineffassign ......... 100%
license ............. 100%
misspell ............ 100%
```

GitHub UI bug (or feature, I'm sure their customer support would say) hides the full test set that passes. You can see that via the last commit that touches the code.
![image](https://github.com/user-attachments/assets/4b354bff-c1c9-47ff-bdb0-6dee10983cba)
